### PR TITLE
Send proxy shutdown message and parsing string message fn

### DIFF
--- a/api.js
+++ b/api.js
@@ -57,7 +57,7 @@ module.exports = function (options, connectionListener) {
 		// Send termination message to all active WebSocket connections
 		Object.values(wsConnections).forEach(ws => {
 			try {
-				ws.send('proxy-shutdown:Proxy server is shutting down. Most probably it is being restarted so try to reconnect.');
+				ws.send('proxy-shutdown:Proxy server is shutting down. Most probably it is being restarted so try to reconnect.', () => {});
 				ws.close();
 			} catch (err) {
 				console.error('Error sending termination message:', err);
@@ -200,7 +200,7 @@ module.exports = function (options, connectionListener) {
 
 		ws.on('message', function (data) {
 			if (typeof data === 'string' && data.startsWith('ping:')) {
-				ws.send('pong:' + data.slice('ping:'.length));
+				ws.send('pong:' + data.slice('ping:'.length), () => {});
 				return
 			}
 			socket.write(data, 'binary', function () {
@@ -216,7 +216,7 @@ module.exports = function (options, connectionListener) {
 		let reasonSent = false;
 		socket.on('timeout', function () {
 			if (!reasonSent) {
-				ws.send('proxy-shutdown:Connection timed out. No packets were sent or received from either side in '+timeout+'ms.');
+				ws.send('proxy-shutdown:Connection timed out. No packets were sent or received from either side in '+timeout+'ms.', () => {});
 				reasonSent = true;
 			}
 		});
@@ -224,7 +224,7 @@ module.exports = function (options, connectionListener) {
 		socket.on('error', function (err) {
 			if (!reasonSent) {
 				const message = err.code === 'EADDRNOTAVAIL' ? 'Minecraft server is not reachable anymore.' : 'Issue with the connection to the Minecraft server: '+err.message;
-				ws.send('proxy-shutdown:'+message);
+				ws.send('proxy-shutdown:'+message, () => {});
 				reasonSent = true;
 			}
 		});
@@ -233,7 +233,7 @@ module.exports = function (options, connectionListener) {
 			// todo let client know of errors somehow
 			myLog('TCP connection closed by remote ('+token+')');
 			if (!reasonSent) {
-				ws.send('proxy-shutdown:Minecraft server closed the connection.');
+				ws.send('proxy-shutdown:Minecraft server closed the connection.', () => {});
 			}
 			ws.close();
 			delete wsConnections[token]; // Clean up WebSocket connection

--- a/browser.js
+++ b/browser.js
@@ -380,6 +380,10 @@ Socket.prototype._connectWebSocket = function (token, cb) {
 	}
 };
 
+Socket.prototype.handleStringMessage = function (message) {
+	return true
+}
+
 Socket.prototype._handleWebsocket = function () {
 	var self = this;
 
@@ -413,8 +417,10 @@ Socket.prototype._handleWebsocket = function () {
 				self.emit('pong', contents.slice('pong:'.length));
 				return
 			}
-			var buffer = new Buffer(contents);
-			gotBuffer(buffer);
+			if (self.handleStringMessage(contents)) {
+				var buffer = new Buffer(contents);
+				gotBuffer(buffer);
+			}
 		} else if (window.Blob && contents instanceof Blob) {
 			var fileReader = new FileReader();
 			let resolveReading


### PR DESCRIPTION
Even if the client doesn't understand `proxy-shutdown:` messages it doesn't matter since the connection will be terminated anyway. But at least it will be visible and readable in DevTools console or other network analyser tool so you can figure out that it was not Minecraft server who terminated the connection.